### PR TITLE
Update file input for CSV uploads

### DIFF
--- a/src/components/csv/FileUploadZone.tsx
+++ b/src/components/csv/FileUploadZone.tsx
@@ -71,7 +71,7 @@ export const FileUploadZone: React.FC<FileUploadZoneProps> = ({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".csv,.txt"
+        accept=".csv,.CSV,text/csv,application/csv,.txt"
         multiple
         onChange={handleFileInputChange}
         className="hidden"


### PR DESCRIPTION
Update file input `accept` attribute to correctly recognize and allow CSV files on mobile and cloud drives.