### PR TITLE
Resolve CSV upload parsing issues

### DIFF
--- a/CSV_DELIMITER_DETECTION_FIX.md
+++ b/CSV_DELIMITER_DETECTION_FIX.md
@@ -1,0 +1,154 @@
+# CSV Delimiter Detection Fix Summary
+
+## Issue Identified
+The root cause of the "Invalid time value" and "0 transactions processed" errors was **incorrect delimiter detection** in the CSV parsing process. New Zealand bank CSV files are typically **tab-delimited** (.tsv format with .csv extension), but the parser was defaulting to comma-delimited parsing.
+
+## Problem Details
+- **UnifiedTransactionProcessor** was using `Papa.parse()` without specifying delimiter detection
+- Papa.parse was defaulting to comma delimiter (`,`) instead of detecting tab delimiter (`\t`)
+- This caused all rows to be treated as single fields instead of being properly split into columns
+- Date and amount parsing failed because the parser couldn't find the actual column values
+- Error messages were generic and didn't provide debugging information
+
+## Solution Implemented
+
+### 1. Fixed Delimiter Auto-Detection
+**File**: `src/services/unifiedTransactionProcessor.ts`
+
+Modified the `Papa.parse` configuration to enable automatic delimiter detection:
+
+```typescript
+Papa.parse(file, {
+  header: true,
+  skipEmptyLines: true,
+  delimiter: "", // Auto-detect delimiter (handles tab-delimited NZ bank files)
+  delimitersToGuess: [',', '\t', '|', ';'], // Common delimiters including tab
+  transformHeader: (header) => header.trim(),
+  // ... rest of config
+});
+```
+
+### 2. Enhanced Error Reporting
+Added detailed error tracking and reporting system:
+
+- **New Method**: `processSingleCSVWithDetails()` - Provides detailed processing results
+- **New Method**: `normalizeTransactionsWithDetails()` - Tracks skipped rows with specific error details
+- **Enhanced Error Messages**: Show actual field values and expected formats
+
+### 3. Improved Date Parsing Error Messages
+Enhanced date parsing errors to show:
+- The actual date value that failed to parse
+- List of supported date formats
+- More descriptive error messages
+
+**Before**: `Invalid or missing date: 12/05/2024`
+**After**: `Invalid date format: "12/05/2024" - Expected formats: DD/MM/YYYY, DD/MM/YY, YYYY-MM-DD, DD MMM YYYY, DD-MM-YY`
+
+### 4. Enhanced Amount Parsing Error Messages
+Improved amount parsing errors to show:
+- Actual debit/credit values when using separate columns
+- Expected column names when amount is missing
+- More specific error context
+
+### 5. Flexible Bank Format Detection
+Enhanced the bank format detection to:
+- Be more flexible with header matching
+- Create universal format when no specific bank format is detected
+- Provide better debugging information
+- Handle edge cases more gracefully
+
+### 6. Better Debugging Output
+Added comprehensive logging throughout the process:
+- Delimiter detection results
+- Bank format detection details
+- Row-by-row processing information
+- Detailed error context
+
+## Key Technical Changes
+
+### Enhanced Data Structures
+```typescript
+// New detailed processing result structure
+interface ProcessingResult {
+  transactions: NormalizedTransaction[];
+  totalRowsProcessed: number;
+  skippedRows: Array<{
+    rowNumber: number;
+    error: string;
+    details?: {
+      dateValue?: string;
+      amountValue?: string;
+      descriptionValue?: string;
+    };
+  }>;
+}
+```
+
+### Improved Error Context
+```typescript
+skippedRows.push({
+  rowNumber,
+  error: error.message,
+  details: {
+    dateValue: dateValue || '[empty]',
+    amountValue: amountValue || '[empty]',
+    descriptionValue: descriptionValue || '[empty]'
+  }
+});
+```
+
+### Universal Format Support
+```typescript
+// Fallback format for non-standard CSV files
+{
+  name: 'Universal',
+  columnMappings: {
+    date: headers.filter(h => h.toLowerCase().includes('date')),
+    description: headers.filter(h => /* flexible description matching */),
+    amount: headers.filter(h => /* flexible amount matching */)
+  }
+}
+```
+
+## Expected Results
+
+### Before Fix
+- ❌ "Invalid time value" errors
+- ❌ "0 transactions processed"
+- ❌ Generic error messages
+- ❌ No debugging information
+- ❌ Tab-delimited files failed completely
+
+### After Fix
+- ✅ Automatic delimiter detection (comma, tab, pipe, semicolon)
+- ✅ Proper parsing of NZ bank CSV files
+- ✅ Detailed error reporting with actual field values
+- ✅ Flexible bank format detection
+- ✅ Better debugging information
+- ✅ Graceful handling of edge cases
+
+## Testing Recommendations
+
+1. **Test with NZ Bank Files**: Upload actual CSV files from ANZ, ASB, Westpac, Kiwibank, BNZ
+2. **Test Tab-Delimited Files**: Specifically test files with tab delimiters
+3. **Test Mixed Delimiters**: Test files with different delimiter types
+4. **Test Error Cases**: Upload files with missing/invalid data to verify error reporting
+5. **Test Edge Cases**: Files with quoted fields, special characters, etc.
+
+## Backward Compatibility
+- All existing functionality preserved
+- Legacy methods maintained for compatibility
+- No breaking changes to public API
+- Enhanced features are additive
+
+## Files Modified
+- `src/services/unifiedTransactionProcessor.ts` - Main fix implementation
+- `src/services/smartFinanceCore.ts` - Enhanced error reporting integration
+
+## Additional Benefits
+- Better user experience with detailed error messages
+- Improved debugging capabilities for developers
+- More robust handling of various CSV formats
+- Enhanced logging for production troubleshooting
+
+This fix addresses the core issue described in the detailed rundown while maintaining backward compatibility and adding significant improvements to error handling and debugging capabilities.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable CSV delimiter auto-detection and enhance error reporting to fix parsing of tab-delimited files and provide clearer debugging.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
NZ bank CSV files are often tab-delimited but were being parsed with a comma delimiter, leading to "Invalid time value" errors and 0 transactions processed. The parser couldn't correctly identify columns. This PR enables automatic delimiter detection (including tab) and significantly improves error reporting by providing specific details like problematic values and row numbers, making debugging much easier.